### PR TITLE
Add DLC

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -124,17 +124,24 @@ globals:
         text: '[最新的LOOT版本](%1%)。'
     subs: [ 'https://loot.github.io/latest-thread/' ]
 
-groups: []
+groups:
+  - name: &dlcGroup DLC
+    description: 'A group for official downloadable content.'
+
+  - name: default
+    after: [ *dlcGroup ]
 
 plugins:
 ###### Official Game Files ######
   - name: 'Update.esm'
     url: [ 'https://store.steampowered.com/app/933480/Enderal_Forgotten_Stories/' ]
+    group: *dlcGroup
     clean:
       - crc: 0xF5E824B0
         util: 'EnderalEdit v4.0.3'
   - name: 'Enderal - Forgotten Stories.esm'
     url: [ 'https://store.steampowered.com/app/933480/Enderal_Forgotten_Stories/' ]
+    group: *dlcGroup
     dirty:
       - <<: *quickClean
         crc: 0xB3DFC9F7

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -129,5 +129,14 @@ groups: []
 plugins:
   - name: 'Update.esm'
     url: [ 'https://store.steampowered.com/app/933480/Enderal_Forgotten_Stories/' ]
+    clean:
+      - crc: 0xF5E824B0
+        util: 'EnderalEdit v4.0.3'
   - name: 'Enderal - Forgotten Stories.esm'
     url: [ 'https://store.steampowered.com/app/933480/Enderal_Forgotten_Stories/' ]
+    dirty:
+      - <<: *quickClean
+        crc: 0xB3DFC9F7
+        util: '[EnderalEdit v4.0.3](https://www.nexusmods.com/enderal/mods/23)'
+        itm: 5
+        udr: 55

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -127,6 +127,7 @@ globals:
 groups: []
 
 plugins:
+###### Official Game Files ######
   - name: 'Update.esm'
     url: [ 'https://store.steampowered.com/app/933480/Enderal_Forgotten_Stories/' ]
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -142,6 +142,9 @@ plugins:
   - name: 'Enderal - Forgotten Stories.esm'
     url: [ 'https://store.steampowered.com/app/933480/Enderal_Forgotten_Stories/' ]
     group: *dlcGroup
+    tag:
+      - Delev
+      - Relev
     dirty:
       - <<: *quickClean
         crc: 0xB3DFC9F7

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -126,4 +126,8 @@ globals:
 
 groups: []
 
-plugins: []
+plugins:
+  - name: 'Update.esm'
+    url: [ 'https://store.steampowered.com/app/933480/Enderal_Forgotten_Stories/' ]
+  - name: 'Enderal - Forgotten Stories.esm'
+    url: [ 'https://store.steampowered.com/app/933480/Enderal_Forgotten_Stories/' ]


### PR DESCRIPTION
Add location
 - https://store.steampowered.com/app/933480/Enderal_Forgotten_Stories/

Add cleaning info
 - Version 1.6.4.0 (Final Patch)

Add comment
 - For section header.

Add group for DLC
 - No order set as it appears to be hard-coded to load Update.esm first.
 - Though I have seen other tools like MO2 and WB set it after the Enderal ESM.

Add Tags
 - Delev & Relev.
 - Changes in leveled lists are reverted without these.